### PR TITLE
Schedule to record in daylight hours

### DIFF
--- a/.idea/gradle.xml
+++ b/.idea/gradle.xml
@@ -3,9 +3,6 @@
   <component name="GradleSettings">
     <option name="linkedExternalProjectsSettings">
       <GradleProjectSettings>
-        <compositeConfiguration>
-          <compositeBuild compositeDefinitionSource="SCRIPT" />
-        </compositeConfiguration>
         <option name="distributionType" value="DEFAULT_WRAPPED" />
         <option name="externalProjectPath" value="$PROJECT_DIR$" />
         <option name="modules">

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -3,7 +3,7 @@
   <component name="EntryPointsManager">
     <entry_points version="2.0" />
   </component>
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_7" project-jdk-name="1.8" project-jdk-type="JavaSDK">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_8" project-jdk-name="1.8" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/build/classes" />
   </component>
   <component name="masterDetails">

--- a/README.md
+++ b/README.md
@@ -3,3 +3,6 @@ Basically this is trying to write a time lapse camera that runs on a regular pre
 Written to take Time Lapse video of my new house construction
 
 Recently updated to run on a pixel 3
+
+Uses [SunriseSunset library](https://github.com/caarmen/SunriseSunset) to calculate sunset/sunrise times so the built-in schedule now tracks
+daylight hours.

--- a/ScheduleTimelapseCam.iml
+++ b/ScheduleTimelapseCam.iml
@@ -8,7 +8,7 @@
       </configuration>
     </facet>
   </component>
-  <component name="NewModuleRootManager" LANGUAGE_LEVEL="JDK_1_7" inherit-compiler-output="true">
+  <component name="NewModuleRootManager" LANGUAGE_LEVEL="JDK_1_8" inherit-compiler-output="true">
     <exclude-output />
     <content url="file://$MODULE_DIR$">
       <excludeFolder url="file://$MODULE_DIR$/.gradle" />

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,10 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 
 buildscript {
+    ext {
+        kotlin_version = '1.3.50'
+    }
+
     repositories {
         google()
         jcenter()
@@ -10,6 +14,7 @@ buildscript {
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:3.5.2'
+        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
 }
 

--- a/camera/build.gradle
+++ b/camera/build.gradle
@@ -1,4 +1,5 @@
 apply plugin: 'com.android.application'
+apply plugin: 'kotlin-android'
 
 android {
     compileSdkVersion 29
@@ -12,14 +13,19 @@ android {
     }
     buildTypes {
         release {
-            //runProguard false
+            minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.txt'
         }
+    }
+    compileOptions {
+        sourceCompatibility = 1.8
+        targetCompatibility = 1.8
     }
 }
 
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
+    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
     implementation 'com.android.support:support-v4:28.0.0'
     implementation 'ca.rmen:lib-sunrise-sunset:1.1.1'
 }

--- a/camera/src/main/java/com/cattailsw/timelapsetest/camera/util/DawnDuskCalculator.kt
+++ b/camera/src/main/java/com/cattailsw/timelapsetest/camera/util/DawnDuskCalculator.kt
@@ -14,6 +14,9 @@ class DawnDuskCalculator {
         val dawn = sunriseSunset[0]
         val dusk = sunriseSunset[1]
 
+        // add 1 hr to each
+        dawn.add(Calendar.HOUR, -1)
+        dusk.add(Calendar.HOUR, 1)
 
         val scheduleData = RecScheduleData(0, 0, 0, dusk.timeInMillis - dawn.timeInMillis, 0)
         scheduleData.startTimeInMillis = dawn.timeInMillis

--- a/camera/src/main/java/com/cattailsw/timelapsetest/camera/util/DawnDuskCalculator.kt
+++ b/camera/src/main/java/com/cattailsw/timelapsetest/camera/util/DawnDuskCalculator.kt
@@ -1,0 +1,23 @@
+package com.cattailsw.timelapsetest.camera.util
+
+import ca.rmen.sunrisesunset.SunriseSunset
+import java.util.*
+
+
+class DawnDuskCalculator {
+
+    /**
+     * should do 1hr before sunrise and 1hr after sunset?
+     */
+    fun getRecordingSchedule(calendar: Calendar): RecScheduleData {
+        val sunriseSunset = SunriseSunset.getCivilTwilight(calendar, 47.6062, -122.3321)
+        val dawn = sunriseSunset[0]
+        val dusk = sunriseSunset[1]
+
+
+        val scheduleData = RecScheduleData(0, 0, 0, dusk.timeInMillis - dawn.timeInMillis, 0)
+        scheduleData.startTimeInMillis = dawn.timeInMillis
+
+        return scheduleData
+    }
+}

--- a/camera/src/main/java/com/cattailsw/timelapsetest/camera/util/RecScheduleData.kt
+++ b/camera/src/main/java/com/cattailsw/timelapsetest/camera/util/RecScheduleData.kt
@@ -1,0 +1,36 @@
+package com.cattailsw.timelapsetest.camera.util
+
+import android.app.AlarmManager
+import java.text.SimpleDateFormat
+import java.util.Calendar
+import java.util.Date
+
+data class RecScheduleData @JvmOverloads constructor(
+        val startHR: Int,
+        val startMin: Int,
+        val startSec: Int,
+        val recordInterval: Long,
+        val repeatInterval: Long = AlarmManager.INTERVAL_DAY, // use AlarmManger.INTERVAL*
+        val recordingFPS: Float = 0.1f) {
+
+    var startTimeInMillis: Long = 0
+
+    val endTimeInMillis: Long
+        get() = startTimeInMillis + recordInterval
+
+    val startTimeString: String
+        get() {
+            val d = Date(startTimeInMillis)
+            val sdf = SimpleDateFormat()
+            return sdf.format(d)
+        }
+
+    init {
+
+        val calendar = Calendar.getInstance()
+        calendar.set(Calendar.HOUR_OF_DAY, startHR)
+        calendar.set(Calendar.MINUTE, startMin)
+        calendar.set(Calendar.SECOND, startSec)
+        startTimeInMillis = calendar.timeInMillis
+    }
+}

--- a/camera/src/main/res/layout/activity_camera.xml
+++ b/camera/src/main/res/layout/activity_camera.xml
@@ -56,12 +56,12 @@
             android:orientation="horizontal"
             tools:ignore="UselessParent">
 
-            <Button android:id="@+id/dummy_button"
+            <Button android:id="@+id/schedule_button"
                 style="?metaButtonBarButtonStyle"
                 android:layout_width="0dp"
                 android:layout_height="wrap_content"
                 android:layout_weight="1"
-                android:onClick="onDummy"
+                android:onClick="onScheduleButton"
                 android:text="@string/dummy_button" />
             <Button android:id="@+id/button_capture"
                 style="?metaButtonBarButtonStyle"


### PR DESCRIPTION
This PR should really be two
- add Kotlin support
- use Sunrise/Sunset time to be schedule recording time so we can record shorter in winter

Moved `RecScheduleData` out into a kotlin data class; uses lib to calculate sunrise/sunset time for Seattle. Hard coded location in code.